### PR TITLE
Fix FAQ crash + favicon 404

### DIFF
--- a/app/[locale]/faq/page.tsx
+++ b/app/[locale]/faq/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import FaqClient, { allFaqKeys } from "@/components/pages/faq-client";
+import FaqClient from "@/components/pages/faq-client";
+import { allFaqKeys } from "@/data/faq-keys";
 import { JsonLd } from "@/components/seo/json-ld";
 
 export async function generateMetadata({

--- a/components/pages/faq-client.tsx
+++ b/components/pages/faq-client.tsx
@@ -13,42 +13,7 @@ import {
 } from "@/components/ui/accordion";
 import { Search, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-// Toutes les clés de FAQ avec leurs catégories
-export const allFaqKeys = [
-	// General
-	{ key: "whatIsWisetwin", category: "general" },
-	{ key: "howHelps", category: "general" },
-	{ key: "whatIsWiseTrainer", category: "general" },
-	{ key: "whatIsWisePaper", category: "general" },
-	{ key: "support", category: "general" },
-	// Features
-	{ key: "trainingTypes", category: "features" },
-	{ key: "existingContent", category: "features" },
-	{ key: "languages", category: "features" },
-	{ key: "progressTracking", category: "features" },
-	{ key: "trainingPlans", category: "features" },
-	{ key: "certifications", category: "features" },
-	{ key: "reminders", category: "features" },
-	{ key: "guestMode", category: "features" },
-	{ key: "createSimulator", category: "features" },
-	{ key: "scenarioTypes", category: "features" },
-	{ key: "hybridTraining", category: "features" },
-	// Pricing
-	{ key: "pricingModel", category: "pricing" },
-	{ key: "wisetrainerPricing", category: "pricing" },
-	{ key: "economicBenefits", category: "pricing" },
-	{ key: "freeTrial", category: "pricing" },
-	// Technical
-	{ key: "deploymentTime", category: "technical" },
-	{ key: "security", category: "technical" },
-	{ key: "noVrHeadset", category: "technical" },
-	{ key: "installation", category: "technical" },
-	{ key: "hrIntegration", category: "technical" },
-	{ key: "multiSite", category: "technical" },
-	{ key: "technicalRequirements", category: "technical" },
-	{ key: "gdprCompliance", category: "technical" },
-] as const;
+import { allFaqKeys } from "@/data/faq-keys";
 
 type Category = "all" | "general" | "features" | "pricing" | "technical";
 

--- a/data/faq-keys.ts
+++ b/data/faq-keys.ts
@@ -1,0 +1,34 @@
+export const allFaqKeys = [
+	// General
+	{ key: "whatIsWisetwin", category: "general" },
+	{ key: "howHelps", category: "general" },
+	{ key: "whatIsWiseTrainer", category: "general" },
+	{ key: "whatIsWisePaper", category: "general" },
+	{ key: "support", category: "general" },
+	// Features
+	{ key: "trainingTypes", category: "features" },
+	{ key: "existingContent", category: "features" },
+	{ key: "languages", category: "features" },
+	{ key: "progressTracking", category: "features" },
+	{ key: "trainingPlans", category: "features" },
+	{ key: "certifications", category: "features" },
+	{ key: "reminders", category: "features" },
+	{ key: "guestMode", category: "features" },
+	{ key: "createSimulator", category: "features" },
+	{ key: "scenarioTypes", category: "features" },
+	{ key: "hybridTraining", category: "features" },
+	// Pricing
+	{ key: "pricingModel", category: "pricing" },
+	{ key: "wisetrainerPricing", category: "pricing" },
+	{ key: "economicBenefits", category: "pricing" },
+	{ key: "freeTrial", category: "pricing" },
+	// Technical
+	{ key: "deploymentTime", category: "technical" },
+	{ key: "security", category: "technical" },
+	{ key: "noVrHeadset", category: "technical" },
+	{ key: "installation", category: "technical" },
+	{ key: "hrIntegration", category: "technical" },
+	{ key: "multiSite", category: "technical" },
+	{ key: "technicalRequirements", category: "technical" },
+	{ key: "gdprCompliance", category: "technical" },
+] as const;

--- a/middleware.ts
+++ b/middleware.ts
@@ -35,7 +35,7 @@ export const config = {
 		// - API routes
 		// - Static files (/_next, /image, /video, etc.)
 		// - Favicon, robots, sitemap
-		"/((?!api|_next|image|video|storyset|ressources|sitemap\\.xml|robots\\.txt|.*\\..*|icon\\.ico).*)",
+		"/((?!api|_next|image|video|storyset|ressources|sitemap\\.xml|robots\\.txt|.*\\..*|icon\\.ico|favicon\\.ico).*)",
 		"/(fr|en)/:path*",
 	],
 };


### PR DESCRIPTION
## Summary
- Fix FAQ page server-side crash (`allFaqKeys.map is not a function`) caused by importing client component data in server component
- Fix favicon.ico 404 by adding it to middleware matcher exclusions

## Details
- Extracted `allFaqKeys` to `data/faq-keys.ts` (shared between server and client)
- Added `favicon\.ico` to middleware matcher pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)